### PR TITLE
Create .gitignore from Java template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
This .gitignore will automatically exclude certain files from being uploaded, such as .class files which should not be uploaded because:
1) The source code to create them is already uploaded.
2) They take up a lot of space and need to be re-made for every machine (roughly) that is going to run the code.